### PR TITLE
Add dynamic = true on UniqueTimeWindowProcessor parameter

### DIFF
--- a/component/src/main/java/io/siddhi/extension/execution/unique/UniqueTimeWindowProcessor.java
+++ b/component/src/main/java/io/siddhi/extension/execution/unique/UniqueTimeWindowProcessor.java
@@ -78,10 +78,12 @@ import java.util.concurrent.ConcurrentMap;
                 @Parameter(name = "unique.key",
                         description = "The attribute that should be checked for uniqueness. ",
                         type = {DataType.INT, DataType.LONG, DataType.FLOAT,
-                                DataType.BOOL, DataType.DOUBLE, DataType.STRING}),
+                                DataType.BOOL, DataType.DOUBLE, DataType.STRING},
+                        dynamic = true),
                 @Parameter(name = "window.time",
                         description = "The sliding time period for which the window should hold events.",
-                        type = {DataType.INT, DataType.LONG})
+                        type = {DataType.INT, DataType.LONG},
+                        dynamic = true)
         },
         parameterOverloads = {
                 @ParameterOverload(parameterNames = {"unique.key", "window.time"})


### PR DESCRIPTION
UniqueTimeWindowProcessor missed the dynamic = true on parameter will cause problem when with siddhi 5.1.7, without dynamic = true it will limite the parameter must be constant

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Goals
When use with siddhi 5.1.7, it shows below errors 
The 'unique:time' expects input parameter 'unique.key' at position '0' to be static, but found a dynamic attribute.

## Approach
very simple fix, and I just add dynamic = true on parameter. and I believe it was a mistake on this commit: https://github.com/siddhi-io/siddhi-execution-unique/commit/0380e39a6af1c976b907665798ad2efe22af3fb2 it just miss add dynamic on this processor

## User stories
N/A

## Release note
Fix but on UniqueTimeWindowProcessor

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
https://github.com/siddhi-io/siddhi-execution-unique/commit/0380e39a6af1c976b907665798ad2efe22af3fb2

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A